### PR TITLE
Update Firefox import.meta status etc.

### DIFF
--- a/index.html
+++ b/index.html
@@ -148,7 +148,7 @@
           <div class="note"><strong>Chrome</strong>: Available in Chrome 61.</div>
           <div class="note"><strong>Firefox</strong>: Available in Firefox 60.</div>
           <div class="note"><strong>Safari</strong>: Available in Safari 10.1.</div>
-          <div class="note"><strong>Edge</strong>: Available.</div>
+          <div class="note"><strong>Edge</strong>: Available in EdgeHTML 16.</div>
         </section>
       </module-feature>
 
@@ -156,7 +156,7 @@
         <h2 slot="label">Worker modules</h2>
         <p slot="desc">Create Web Workers that are modules (and are able to import other modules) using <code>new Worker(path, {type: "module"})</code></p>
         <section slot="notes">
-          <div class="note"><strong>Chrome</strong>: <a href="https://bugs.chromium.org/p/chromium/issues/detail?id=680046">In development.</a>.</div>
+          <div class="note"><strong>Chrome</strong>: <a href="https://bugs.chromium.org/p/chromium/issues/detail?id=680046">In development</a>.</div>
           <div class="note"><strong>Firefox</strong>: <a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1247687">Not yet in progress</a>.</div>
           <div class="note"><strong>Safari</strong>: Not yet implemented.</div>
           <div class="note"><strong>Edge</strong>: Not yet implemented.</div>
@@ -170,7 +170,7 @@
           <div class="note"><strong>Chrome</strong>: Available in Chrome 63.</div>
           <div class="note"><strong>Firefox</strong>: <a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1342012">Not yet in progress</a>.</div>
           <div class="note"><strong>Safari</strong>: Available.</div>
-          <div class="note"><strong>Edge</strong>: Not yet implemented.</div>
+          <div class="note"><strong>Edge</strong>: <a href="https://developer.microsoft.com/en-us/microsoft-edge/platform/status/javascriptmoduleimport/">In development</a>.</div>
         </section>
       </module-feature>
 

--- a/index.html
+++ b/index.html
@@ -179,7 +179,7 @@
         <p slot="desc">Provides the <a href="https://url.spec.whatwg.org/">URL</a> of the module.</p>
         <section slot="notes">
           <div class="note"><strong>Chrome</strong>: Available in Chrome 64.</div>
-          <div class="note"><strong>Firefox</strong>: Not yet implemented.</div>
+          <div class="note"><strong>Firefox</strong>: Available in Firefox 62.</div>
           <div class="note"><strong>Safari</strong>: Available in Safari 11.1</div>
           <div class="note"><strong>Edge</strong>: Not yet implemented.</div>
         </section>

--- a/js/app.js
+++ b/js/app.js
@@ -14,8 +14,8 @@ class AreModulesReady extends Element {
     this.model.workers = [chrome(false, true, true), firefox(false),
       edge(false), safari(false)];
     this.model.dynamic = [chrome(true), firefox(false),
-      edge(false), safari(true)];
     this.model.metaUrl = [chrome(true), firefox(false),
+      edge(false, true, true), safari(true)];
       edge(false), safari(true)];
   }
 }

--- a/js/app.js
+++ b/js/app.js
@@ -14,8 +14,8 @@ class AreModulesReady extends Element {
     this.model.workers = [chrome(false, true, true), firefox(false),
       edge(false), safari(false)];
     this.model.dynamic = [chrome(true), firefox(false),
-    this.model.metaUrl = [chrome(true), firefox(false),
       edge(false, true, true), safari(true)];
+    this.model.metaUrl = [chrome(true), firefox(true),
       edge(false), safari(true)];
   }
 }


### PR DESCRIPTION
This PR:

1. adds Edge version info for [basic module support](https://developer.microsoft.com/en-us/microsoft-edge/platform/status/javascriptmoduleimport/)
2. fixes a typo
3. updates `import()` status of Edge as `In development`
4. [updates `import.meta.url` status of Firefox](https://bugzilla.mozilla.org/show_bug.cgi?id=1427610).